### PR TITLE
feat: Implement initial screens and basic theme structure

### DIFF
--- a/com.example.cosmeticlumea/MainActivity.kt
+++ b/com.example.cosmeticlumea/MainActivity.kt
@@ -1,0 +1,5 @@
+// Empty MainActivity.kt
+package com.example.cosmeticlumea
+
+class MainActivity {
+}

--- a/com.example.cosmeticlumea/Routes.kt
+++ b/com.example.cosmeticlumea/Routes.kt
@@ -1,0 +1,16 @@
+package com.example.cosmeticlumea
+
+object Routes {
+    object Onboarding { val route = "onboarding" }
+    object Login { val route = "login" }
+    object Register { val route = "register" }
+    object Home { val route = "home" }
+    object Detail {
+        const val route = "detail_screen" // Changed to avoid conflict with potential 'detail' keyword
+        const val argProductId = "productId"
+        // Example: detail_screen/123
+        val routeWithArg = "$route/{$argProductId}"
+    }
+    object Cart { val route = "cart" } // Anticipating
+    object Profile { val route = "profile" } // Anticipating
+}

--- a/com.example.cosmeticlumea/data/ProductData.kt
+++ b/com.example.cosmeticlumea/data/ProductData.kt
@@ -1,0 +1,26 @@
+package com.example.cosmeticlumea.data
+
+import com.example.cosmeticlumea.R // Make sure R is imported if not automatically
+
+// Define a simple Product data class
+data class Product(
+    val id: Int,
+    val name: String,
+    val price: String,
+    val imageResId: Int, // Using Int for drawable resource ID
+    val description: String = "This is a fantastic product that you will absolutely love. It has all the features you need and more. Made from the highest quality materials, ensuring durability and a premium feel. Perfect for daily use or as a special gift."
+)
+
+// Sample product data
+val sampleProductsList = listOf(
+    Product(1, "Luxury Lipstick", "€25.99", R.drawable.product_placeholder, "A luxurious lipstick with a creamy matte finish. Provides long-lasting color and hydration. Available in 12 stunning shades."),
+    Product(2, "Silk Foundation", "€45.50", R.drawable.product_placeholder, "Lightweight silk foundation that provides flawless coverage and a natural, dewy glow. Suitable for all skin types."),
+    Product(3, "Eyeshadow Palette", "€30.00", R.drawable.product_placeholder, "A versatile eyeshadow palette with 18 highly pigmented shades, ranging from mattes to shimmers. Create endless looks for day and night."),
+    Product(4, "Nourishing Night Cream", "€55.20", R.drawable.product_placeholder, "A rich and nourishing night cream that repairs and rejuvenates your skin while you sleep. Wake up to softer, smoother, and more radiant skin."),
+    Product(5, "Vitamin C Serum", "€35.00", R.drawable.product_placeholder, "Brighten and protect your skin with this potent Vitamin C serum. Helps to reduce dark spots, even out skin tone, and boost collagen production."),
+    Product(6, "Organic Mascara", "€19.99", R.drawable.product_placeholder, "Define and lengthen your lashes with this organic mascara. Gentle formula, perfect for sensitive eyes. Smudge-proof and long-lasting.")
+)
+
+fun getProductById(productId: Int?): Product? {
+    return sampleProductsList.find { it.id == productId }
+}

--- a/com.example.cosmeticlumea/nav/NavGraph.kt
+++ b/com.example.cosmeticlumea/nav/NavGraph.kt
@@ -1,0 +1,5 @@
+// Empty NavGraph.kt
+package com.example.cosmeticlumea.nav
+
+class NavGraph {
+}

--- a/com.example.cosmeticlumea/screens/CartScreen.kt
+++ b/com.example.cosmeticlumea/screens/CartScreen.kt
@@ -1,0 +1,150 @@
+package com.example.cosmeticlumea.screens
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.example.cosmeticlumea.data.Product // Reusing Product data class
+import com.example.cosmeticlumea.data.sampleProductsList // For sample item
+import com.example.cosmeticlumea.ui.theme.CosmeticLumeaTheme
+
+// Simulate a cart - in a real app, this would come from a ViewModel or repository
+private val sampleCartItems = mutableStateListOf<Product>()
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CartScreen(navController: NavController) {
+    // For demonstration, let's add/remove a sample item to test both states.
+    // This is a temporary way to toggle state for preview/testing.
+    // In a real app, cart state would be managed more robustly.
+    // var showSampleItem by remember { mutableStateOf(true) } // Or manage sampleCartItems directly
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Shopping Cart") },
+                // Navigation icon can be added if this screen isn't part of main bottom nav flow directly
+                // or if it can be accessed from somewhere else.
+                // For now, assuming it's part of BottomNav, so no explicit back.
+                // If it needs a back button:
+                // navigationIcon = {
+                //     IconButton(onClick = { navController.popBackStack() }) {
+                //         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                //     }
+                // }
+            )
+        }
+    ) { paddingValues ->
+        // Simulate adding an item for the "sample" state for preview purposes
+        // LaunchedEffect(Unit) {
+        // if (sampleCartItems.isEmpty()) { // Add only if empty to avoid duplicates on recomposition
+        // sampleCartItems.add(sampleProductsList[0])
+        // }
+        // }
+
+        if (sampleCartItems.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text("Your cart is empty.", style = MaterialTheme.typography.headlineSmall)
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .fillMaxSize(),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                items(sampleCartItems) { product ->
+                    CartItemRow(product = product)
+                }
+                // Potentially a summary section
+                item {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text("Total: ${calculateTotalPrice(sampleCartItems)}", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Button(onClick = { /* TODO: Checkout */ }, modifier = Modifier.fillMaxWidth()) {
+                        Text("Proceed to Checkout")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun CartItemRow(product: Product) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Image(
+            painter = painterResource(id = product.imageResId),
+            contentDescription = product.name,
+            modifier = Modifier
+                .size(80.dp)
+                .padding(end = 16.dp),
+            contentScale = ContentScale.Crop
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(product.name, style = MaterialTheme.typography.titleMedium)
+            Text(product.price, style = MaterialTheme.typography.bodyMedium)
+        }
+        // For simplicity, not adding quantity selectors or remove buttons yet
+        Text("Qty: 1", style = MaterialTheme.typography.bodyMedium) // Static quantity
+    }
+}
+
+fun calculateTotalPrice(cartItems: List<Product>): String {
+    // This is a very basic price calculation, assuming price is like "€XX.YY"
+    val total = cartItems.sumOf {
+        it.price.replace("€", "").toDoubleOrNull() ?: 0.0
+    }
+    return String.format("€%.2f", total)
+}
+
+
+// Previews for both states
+@Preview(name = "Cart Screen - Empty", showBackground = true)
+@Composable
+fun CartScreenEmptyPreview() {
+    CosmeticLumeaTheme {
+        Surface {
+            // Ensure cart is empty for this preview
+            sampleCartItems.clear()
+            CartScreen(navController = rememberNavController())
+        }
+    }
+}
+
+@Preview(name = "Cart Screen - With Item", showBackground = true)
+@Composable
+fun CartScreenWithItemPreview() {
+    CosmeticLumeaTheme {
+        Surface {
+            // Ensure cart has an item for this preview
+            if (sampleCartItems.isEmpty()) {
+                sampleCartItems.add(sampleProductsList[0]) // Add a sample product
+                 if(sampleProductsList.size > 1) sampleCartItems.add(sampleProductsList[1]) // Add another for testing total
+            }
+            CartScreen(navController = rememberNavController())
+        }
+    }
+}

--- a/com.example.cosmeticlumea/screens/DetailScreen.kt
+++ b/com.example.cosmeticlumea/screens/DetailScreen.kt
@@ -1,0 +1,117 @@
+package com.example.cosmeticlumea.screens
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.example.cosmeticlumea.data.Product // Import from data package
+import com.example.cosmeticlumea.data.getProductById // Import from data package
+import com.example.cosmeticlumea.data.sampleProductsList // For preview
+import com.example.cosmeticlumea.ui.theme.CosmeticLumeaTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DetailScreen(navController: NavController, productId: String?) {
+    val product = getProductById(productId?.toIntOrNull())
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(product?.name ?: "Product Details") },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        if (product != null) {
+            Column(
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Image(
+                    painter = painterResource(id = product.imageResId),
+                    contentDescription = product.name,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(250.dp)
+                        .padding(bottom = 16.dp),
+                    contentScale = ContentScale.Crop
+                )
+                Text(
+                    text = product.name,
+                    style = MaterialTheme.typography.headlineMedium,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+                Text(
+                    text = product.price,
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+                Text(
+                    text = product.description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Justify, // Or TextAlign.Start
+                    modifier = Modifier.padding(bottom = 24.dp)
+                )
+                Button(
+                    onClick = { /* TODO: Add to cart logic */ },
+                    modifier = Modifier.fillMaxWidth(0.8f)
+                ) {
+                    Text("Add to Cart")
+                }
+                Spacer(modifier = Modifier.height(16.dp)) // Space at the bottom
+            }
+        } else {
+            Box(
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text("Product not found.", style = MaterialTheme.typography.labelLarge)
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DetailScreenPreview() {
+    CosmeticLumeaTheme {
+        Surface {
+            // Preview with a sample product
+            DetailScreen(navController = rememberNavController(), productId = sampleProductsList[0].id.toString())
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DetailScreenProductNotFoundPreview() {
+    CosmeticLumeaTheme {
+        Surface {
+            DetailScreen(navController = rememberNavController(), productId = "999") // Non-existent ID
+        }
+    }
+}

--- a/com.example.cosmeticlumea/screens/HomeScreen.kt
+++ b/com.example.cosmeticlumea/screens/HomeScreen.kt
@@ -1,0 +1,121 @@
+package com.example.cosmeticlumea.screens
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.example.cosmeticlumea.R // Assuming R class
+import com.example.cosmeticlumea.Routes
+import com.example.cosmeticlumea.ui.theme.CosmeticLumeaTheme
+
+// Define a simple Product data class
+data class Product(
+    val id: Int,
+    val name: String,
+    val price: String,
+    val imageResId: Int // Using Int for drawable resource ID
+)
+
+// Sample product data
+val sampleProducts = listOf(
+    Product(1, "Luxury Lipstick", "€25.99", R.drawable.product_placeholder),
+    Product(2, "Silk Foundation", "€45.50", R.drawable.product_placeholder),
+    Product(3, "Eyeshadow Palette", "€30.00", R.drawable.product_placeholder),
+    Product(4, "Nourishing Night Cream", "€55.20", R.drawable.product_placeholder),
+    Product(5, "Vitamin C Serum", "€35.00", R.drawable.product_placeholder),
+    Product(6, "Organic Mascara", "€19.99", R.drawable.product_placeholder)
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeScreen(navController: NavController) {
+    // In a real app, this would likely be part of MainScreen with BottomNav
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("CosmeticLumea") })
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize(),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            items(sampleProducts) { product ->
+                ProductCard(product = product) {
+                    navController.navigate("${Routes.Detail.route}/${product.id}")
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProductCard(product: Product, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column {
+            Image(
+                painter = painterResource(id = product.imageResId), // Will fail if placeholder doesn't exist
+                contentDescription = product.name,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(180.dp),
+                contentScale = ContentScale.Crop
+            )
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(text = product.name, style = MaterialTheme.typography.titleMedium)
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(text = product.price, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.primary)
+            }
+        }
+    }
+}
+
+// Update Routes.kt
+// package com.example.cosmeticlumea
+// object Routes {
+//     // ... other routes
+//     object Detail {
+//         const val route = "detail"
+//         const val argProductId = "productId"
+//         val routeWithArg = "$route/{$argProductId}"
+//     }
+// }
+
+@Preview(showBackground = true)
+@Composable
+fun HomeScreenPreview() {
+    CosmeticLumeaTheme {
+        Surface {
+            HomeScreen(navController = rememberNavController())
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ProductCardPreview() {
+    CosmeticLumeaTheme {
+        Surface {
+            ProductCard(product = sampleProducts[0], onClick = {})
+        }
+    }
+}

--- a/com.example.cosmeticlumea/screens/LoginScreen.kt
+++ b/com.example.cosmeticlumea/screens/LoginScreen.kt
@@ -1,0 +1,128 @@
+package com.example.cosmeticlumea.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.example.cosmeticlumea.Routes
+import com.example.cosmeticlumea.ui.theme.CosmeticLumeaTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LoginScreen(navController: NavController) {
+    var username by rememberSaveable { mutableStateOf("") }
+    var password by rememberSaveable { mutableStateOf("") }
+    var passwordVisible by rememberSaveable { mutableStateOf(false) }
+    var rememberMe by rememberSaveable { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Login", style = MaterialTheme.typography.headlineLarge)
+        Spacer(modifier = Modifier.height(32.dp))
+
+        OutlinedTextField(
+            value = username,
+            onValueChange = { username = it },
+            label = { Text("Username") },
+            leadingIcon = { Icon(Icons.Filled.Person, contentDescription = "Username Icon") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = password,
+            onValueChange = { password = it },
+            label = { Text("Password") },
+            leadingIcon = { Icon(Icons.Filled.Lock, contentDescription = "Password Icon") },
+            trailingIcon = {
+                val image = if (passwordVisible) Icons.Filled.VisibilityOff else Icons.Filled.Visibility
+                val description = if (passwordVisible) "Hide password" else "Show password"
+                IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                    Icon(imageVector = image, description)
+                }
+            },
+            visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Switch(checked = rememberMe, onCheckedChange = { rememberMe = it })
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Remember me")
+            }
+            TextButton(onClick = { /* TODO: Handle forgot password */ }) {
+                Text("Forgot password?")
+            }
+        }
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Button(
+            onClick = { navController.navigate(Routes.Home.route) },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Login")
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text("Or login with", style = MaterialTheme.typography.bodyMedium)
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            IconButton(onClick = { /* TODO: Handle Google login */ }) {
+                Icon(Icons.Filled.AccountCircle, contentDescription = "Google Login", modifier = Modifier.size(40.dp)) // Placeholder
+            }
+            IconButton(onClick = { /* TODO: Handle Facebook login */ }) {
+                Icon(Icons.Filled.AccountCircle, contentDescription = "Facebook Login", modifier = Modifier.size(40.dp)) // Placeholder
+            }
+        }
+    }
+}
+
+// Update Routes.kt
+// package com.example.cosmeticlumea
+// object Routes {
+//     object Onboarding { val route = "onboarding" }
+//     object Login { val route = "login" }
+//     object Home { val route = "home" } // Added Home
+//     // Add other routes here as they are created
+// }
+
+@Preview(showBackground = true)
+@Composable
+fun LoginScreenPreview() {
+    CosmeticLumeaTheme {
+        Surface {
+            LoginScreen(navController = rememberNavController())
+        }
+    }
+}

--- a/com.example.cosmeticlumea/screens/MainScreen.kt
+++ b/com.example.cosmeticlumea/screens/MainScreen.kt
@@ -1,0 +1,5 @@
+// Empty MainScreen.kt
+package com.example.cosmeticlumea.screens
+
+class MainScreen {
+}

--- a/com.example.cosmeticlumea/screens/OnboardingScreen.kt
+++ b/com.example.cosmeticlumea/screens/OnboardingScreen.kt
@@ -1,0 +1,95 @@
+package com.example.cosmeticlumea.screens
+
+import android.content.res.Configuration
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.example.cosmeticlumea.R // Assuming R class will be generated
+import com.example.cosmeticlumea.Routes
+import com.example.cosmeticlumea.ui.theme.CosmeticLumeaTheme
+
+@Composable
+fun OnboardingScreen(navController: NavController) {
+    val configuration = LocalConfiguration.current
+    val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+    // Placeholder for image resource ID
+    // In a real app, you would have different images or layouts
+    val backgroundImageRes = if (isLandscape) {
+        R.drawable.onboarding_landscape // Placeholder
+    } else {
+        R.drawable.onboarding_portrait // Placeholder
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Image(
+            painter = painterResource(id = backgroundImageRes), // This will cause an error if not available
+            contentDescription = "Onboarding Background",
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.Bottom,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Welcome to CosmeticLumea", // Replace with stringResource if needed
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer // Or a color that contrasts with image
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Your one-stop shop for beauty products.", // Replace with stringResource
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onPrimaryContainer // Or a color that contrasts
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+            Button(
+                onClick = { navController.navigate(Routes.Login.route) },
+                modifier = Modifier.fillMaxWidth(0.8f)
+            ) {
+                Text(text = "Next")
+            }
+            Spacer(modifier = Modifier.height(48.dp)) // Added space at the bottom
+        }
+    }
+}
+
+// Minimal Routes.kt for compilation
+// package com.example.cosmeticlumea
+// object Routes {
+//     object Login { const val route = "login" }
+//     object Onboarding { const val route = "onboarding" }
+// }
+
+@Preview(name = "Portrait Mode", showBackground = true)
+@Preview(name = "Landscape Mode", showBackground = true, widthDp = 720, heightDp = 360)
+@Composable
+fun OnboardingScreenPreview() {
+    CosmeticLumeaTheme {
+        Surface {
+            // In Preview, NavController isn't easily available.
+            // We can pass a dummy one or structure code to make NavController optional for preview.
+            // For simplicity, creating a dummy one for preview.
+            OnboardingScreen(navController = rememberNavController())
+        }
+    }
+}

--- a/com.example.cosmeticlumea/screens/ProfileScreen.kt
+++ b/com.example.cosmeticlumea/screens/ProfileScreen.kt
@@ -1,0 +1,5 @@
+// Empty ProfileScreen.kt
+package com.example.cosmeticlumea.screens
+
+class ProfileScreen {
+}

--- a/com.example.cosmeticlumea/screens/RegisterScreen.kt
+++ b/com.example.cosmeticlumea/screens/RegisterScreen.kt
@@ -1,0 +1,95 @@
+package com.example.cosmeticlumea.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.example.cosmeticlumea.Routes
+import com.example.cosmeticlumea.ui.theme.CosmeticLumeaTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RegisterScreen(navController: NavController) {
+    var name by rememberSaveable { mutableStateOf("") }
+    var email by rememberSaveable { mutableStateOf("") }
+    var password by rememberSaveable { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp)
+            .verticalScroll(rememberScrollState()), // Added for scrollability
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Create Account", style = MaterialTheme.typography.headlineLarge)
+        Spacer(modifier = Modifier.height(32.dp))
+
+        OutlinedTextField(
+            value = name,
+            onValueChange = { name = it },
+            label = { Text("Full Name") },
+            leadingIcon = { Icon(Icons.Filled.Person, contentDescription = "Name Icon") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = email,
+            onValueChange = { email = it },
+            label = { Text("Email") },
+            leadingIcon = { Icon(Icons.Filled.Email, contentDescription = "Email Icon") },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = password,
+            onValueChange = { password = it },
+            label = { Text("Password") },
+            leadingIcon = { Icon(Icons.Filled.Lock, contentDescription = "Password Icon") },
+            visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Button(
+            onClick = { /* TODO: Handle registration logic -> then navigate, perhaps to login or home */ },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Register")
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+
+        TextButton(onClick = { navController.navigate(Routes.Login.route) }) {
+            Text("Already have an account? Login")
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RegisterScreenPreview() {
+    CosmeticLumeaTheme {
+        Surface {
+            RegisterScreen(navController = rememberNavController())
+        }
+    }
+}

--- a/com.example.cosmeticlumea/ui/theme/Color.kt
+++ b/com.example.cosmeticlumea/ui/theme/Color.kt
@@ -1,0 +1,56 @@
+package com.example.cosmeticlumea.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val Purple80 = Color(0xFFD0BCFF)
+val PurpleGrey80 = Color(0xFFCCC2DC)
+val Pink80 = Color(0xFFEFB8C8)
+
+val Purple40 = Color(0xFF6650a4)
+val PurpleGrey40 = Color(0xFF625b71)
+val Pink40 = Color(0xFF7D5260)
+
+// CosmeticLumea specific colors (placeholders for now)
+val PrimaryLight = Purple40
+val OnPrimaryLight = Color.White
+val PrimaryContainerLight = PurpleGrey40
+val OnPrimaryContainerLight = Color.White
+val SecondaryLight = Pink40
+val OnSecondaryLight = Color.White
+val SecondaryContainerLight = Pink80
+val OnSecondaryContainerLight = PurpleGrey80
+val TertiaryLight = Color(0xFFB5838D)
+val OnTertiaryLight = Color.White
+val TertiaryContainerLight = Color(0xFFE5A9A9)
+val OnTertiaryContainerLight = Color(0xFF4A2525)
+val ErrorLight = Color(0xFFB00020)
+val OnErrorLight = Color.White
+val BackgroundLight = Color(0xFFFFFbff)
+val OnBackgroundLight = Color(0xFF1C1B1F)
+val SurfaceLight = Color(0xFFFFFbff)
+val OnSurfaceLight = Color(0xFF1C1B1F)
+val SurfaceVariantLight = Color(0xFFE7E0EC)
+val OnSurfaceVariantLight = Color(0xFF49454F)
+val OutlineLight = Color(0xFF79747E)
+
+val PrimaryDark = Purple80
+val OnPrimaryDark = PurpleGrey80
+val PrimaryContainerDark = Purple40
+val OnPrimaryContainerDark = Color.White
+val SecondaryDark = Pink80
+val OnSecondaryDark = PurpleGrey40
+val SecondaryContainerDark = Pink40
+val OnSecondaryContainerDark = Color.White
+val TertiaryDark = Color(0xFFE5A9A9)
+val OnTertiaryDark = Color(0xFF4A2525)
+val TertiaryContainerDark = Color(0xFFB5838D)
+val OnTertiaryContainerDark = Color.White
+val ErrorDark = Color(0xFFCF6679)
+val OnErrorDark = Color.Black
+val BackgroundDark = Color(0xFF1C1B1F)
+val OnBackgroundDark = Color(0xFFE6E1E5)
+val SurfaceDark = Color(0xFF1C1B1F)
+val OnSurfaceDark = Color(0xFFE6E1E5)
+val SurfaceVariantDark = Color(0xFF49454F)
+val OnSurfaceVariantDark = Color(0xFFCAC4D0)
+val OutlineDark = Color(0xFF938F99)

--- a/com.example.cosmeticlumea/ui/theme/Theme.kt
+++ b/com.example.cosmeticlumea/ui/theme/Theme.kt
@@ -1,0 +1,94 @@
+package com.example.cosmeticlumea.ui.theme
+
+import android.app.Activity
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+
+private val DarkColorScheme = darkColorScheme(
+    primary = PrimaryDark,
+    onPrimary = OnPrimaryDark,
+    primaryContainer = PrimaryContainerDark,
+    onPrimaryContainer = OnPrimaryContainerDark,
+    secondary = SecondaryDark,
+    onSecondary = OnSecondaryDark,
+    secondaryContainer = SecondaryContainerDark,
+    onSecondaryContainer = OnSecondaryContainerDark,
+    tertiary = TertiaryDark,
+    onTertiary = OnTertiaryDark,
+    tertiaryContainer = TertiaryContainerDark,
+    onTertiaryContainer = OnTertiaryContainerDark,
+    error = ErrorDark,
+    onError = OnErrorDark,
+    background = BackgroundDark,
+    onBackground = OnBackgroundDark,
+    surface = SurfaceDark,
+    onSurface = OnSurfaceDark,
+    surfaceVariant = SurfaceVariantDark,
+    onSurfaceVariant = OnSurfaceVariantDark,
+    outline = OutlineDark
+)
+
+private val LightColorScheme = lightColorScheme(
+    primary = PrimaryLight,
+    onPrimary = OnPrimaryLight,
+    primaryContainer = PrimaryContainerLight,
+    onPrimaryContainer = OnPrimaryContainerLight,
+    secondary = SecondaryLight,
+    onSecondary = OnSecondaryLight,
+    secondaryContainer = SecondaryContainerLight,
+    onSecondaryContainer = OnSecondaryContainerLight,
+    tertiary = TertiaryLight,
+    onTertiary = OnTertiaryLight,
+    tertiaryContainer = TertiaryContainerLight,
+    onTertiaryContainer = OnTertiaryContainerLight,
+    error = ErrorLight,
+    onError = OnErrorLight,
+    background = BackgroundLight,
+    onBackground = OnBackgroundLight,
+    surface = SurfaceLight,
+    onSurface = OnSurfaceLight,
+    surfaceVariant = SurfaceVariantLight,
+    onSurfaceVariant = OnSurfaceVariantLight,
+    outline = OutlineLight
+)
+
+@Composable
+fun CosmeticLumeaTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    // Dynamic color is available on Android S+
+    dynamicColor: Boolean = true,
+    content: @Composable () -> Unit
+) {
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+        darkTheme -> DarkColorScheme
+        else -> LightColorScheme
+    }
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            window.statusBarColor = colorScheme.primary.toArgb() // Or any other color
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
+            // For navigation bar color
+            // window.navigationBarColor = colorScheme.primary.toArgb() // Or any other color
+            // WindowCompat.getInsetsController(window, view).isAppearanceLightNavigationBars = !darkTheme
+        }
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = Typography,
+        content = content
+    )
+}

--- a/com.example.cosmeticlumea/ui/theme/Type.kt
+++ b/com.example.cosmeticlumea/ui/theme/Type.kt
@@ -1,0 +1,118 @@
+package com.example.cosmeticlumea.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+// Replace with your chosen font families if you have custom fonts
+val AppFontFamily = FontFamily.Default // Placeholder
+
+val Typography = Typography(
+    displayLarge = TextStyle(
+        fontFamily = AppFontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = 57.sp,
+        lineHeight = 64.sp,
+        letterSpacing = (-0.25).sp
+    ),
+    displayMedium = TextStyle(
+        fontFamily = AppFontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = 45.sp,
+        lineHeight = 52.sp,
+        letterSpacing = 0.sp
+    ),
+    displaySmall = TextStyle(
+        fontFamily = AppFontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = 36.sp,
+        lineHeight = 44.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineLarge = TextStyle(
+        fontFamily = AppFontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = 32.sp,
+        lineHeight = 40.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineMedium = TextStyle(
+        fontFamily = AppFontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = 28.sp,
+        lineHeight = 36.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineSmall = TextStyle(
+        fontFamily = AppFontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = 24.sp,
+        lineHeight = 32.sp,
+        letterSpacing = 0.sp
+    ),
+    titleLarge = TextStyle(
+        fontFamily = AppFontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+        letterSpacing = 0.sp
+    ),
+    titleMedium = TextStyle(
+        fontFamily = AppFontFamily,
+        fontWeight = FontWeight.Medium,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.15.sp
+    ),
+    titleSmall = TextStyle(
+        fontFamily = AppFontFamily,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp
+    ),
+    bodyLarge = TextStyle(
+        fontFamily = AppFontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.5.sp
+    ),
+    bodyMedium = TextStyle(
+        fontFamily = AppFontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.25.sp
+    ),
+    bodySmall = TextStyle(
+        fontFamily = AppFontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.4.sp
+    ),
+    labelLarge = TextStyle(
+        fontFamily = AppFontFamily,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp
+    ),
+    labelMedium = TextStyle(
+        fontFamily = AppFontFamily,
+        fontWeight = FontWeight.Medium,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
+    ),
+    labelSmall = TextStyle(
+        fontFamily = AppFontFamily,
+        fontWeight = FontWeight.Medium,
+        fontSize = 11.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
+    )
+)

--- a/src/main/res/drawable/onboarding_landscape.xml
+++ b/src/main/res/drawable/onboarding_landscape.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@android:color/darker_gray"/>
+</shape>

--- a/src/main/res/drawable/onboarding_portrait.xml
+++ b/src/main/res/drawable/onboarding_portrait.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@android:color/darker_gray"/>
+</shape>

--- a/src/main/res/drawable/product_placeholder.xml
+++ b/src/main/res/drawable/product_placeholder.xml
@@ -1,0 +1,6 @@
+<!-- res/drawable/product_placeholder.xml -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#E0E0E0"/> <!-- Light gray color -->
+    <size android:width="200dp" android:height="200dp"/>
+</shape>


### PR DESCRIPTION
This commit includes the setup of the Android project structure and the implementation of several initial screens for your CosmeticLumea app:

- Project Structure: I created directories and Kotlin files for screens, navigation, and UI theme.
- Theme: I implemented a basic Material Design 3 theme in ui/theme/ (Color.kt, Type.kt, Theme.kt) with placeholder purple-based colors for light/dark modes. (You provided feedback to change to pink #FF0066 later).
- OnboardingScreen: Full-screen background (different for landscape), title, subtitle, and 'Next' button.
- LoginScreen: Username/password fields, password visibility toggle, 'Remember me' switch, 'Forgot password' text, social login placeholders.
- RegisterScreen: Name, email, password fields, 'Register' button, link to Login.
- HomeScreen: Scrollable LazyColumn of product cards (static data, placeholder images), navigation to DetailScreen.
- DetailScreen: Displays static product name, image, description, and a non-functional 'Add to cart' button.
- CartScreen: Shows 'Cart is empty' or a LazyColumn with a sample product (static data).

Navigation between these screens is partially set up via NavController. Routes are defined in Routes.kt. Placeholder images and data are used as per your initial requirements.

Next, I planned to work on the Profile Screen.